### PR TITLE
eki-form darker; removed eki-stress::after

### DIFF
--- a/wordweb-app/src/main/resources/scss/eki-markup.scss
+++ b/wordweb-app/src/main/resources/scss/eki-markup.scss
@@ -23,6 +23,13 @@ eki-stress {
   }
 }
 
+.corp-panel eki-stress::after {
+  content: none;
+}
+.corp-panel eki-stress {
+  font-weight: bold;
+}
+
 eki-sub {
   font-size: 70%;
   vertical-align: sub;
@@ -44,7 +51,7 @@ eki-link {
 }
 
 eki-form { 
-  color: #28b463;
+  color: #006321;
 }
 
 eki-shy::before {


### PR DESCRIPTION
eki-stress in form of appended ´ allows browsers to break words in narrow column