### PR TITLE
Update corpus service URLs and details

### DIFF
--- a/wordweb-app/src/main/resources/application.properties
+++ b/wordweb-app/src/main/resources/application.properties
@@ -49,8 +49,8 @@ morpho.synthesizer.service.url=https://teenus.eki.ee/vormisyntees
 speech.synthesizer.service.url=https://kiisu.eki.ee/konesyntees
 speech.recognition.service.url=ws://bark.phon.ioc.ee:82/dev/duplex-speech-api/ws/speech
 
-corpus.service.est.url=https://korp.keeleressursid.ee/cgi-bin/kuuskorp.cgi
-corpus.service.est.corpname.detail=SONAVEEB2021
+corpus.service.est.url=https://korp.eki.ee/api/query
+corpus.service.est.corpname.detail=SONAVEEB_2023
 corpus.service.est.word.key.detail=lempos
 corpus.service.est.corpname.simple=COURSEBOOK2018
 corpus.service.est.word.key.simple=baseform


### PR DESCRIPTION
Changes KORP service to EKI hosted instance and also changes the underlying corpus to a newer version (2023). Corpus structure and configuration is identical so no code changes should be necessary, but complete compatibility should be tested before use in production.